### PR TITLE
updating SSX processing result table + new permission for the beamlin…

### DIFF
--- a/schema/updates/2024_11_26_Beamline_service_permissions.sql
+++ b/schema/updates/2024_11_26_Beamline_service_permissions.sql
@@ -1,0 +1,7 @@
+INSERT INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2024_11_26_Beamline_service_permissions.sql', 'ONGOING');
+
+INSERT INTO Permission (permissionId,`type`,description)
+	VALUES (104,'bl_service','Beamline service');
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2024_11_26_Beamline_service_permissions.sql';
+

--- a/schema/updates/2024_11_26_SSX_processing_results_dataCollectionId_Mandatory.sql
+++ b/schema/updates/2024_11_26_SSX_processing_results_dataCollectionId_Mandatory.sql
@@ -1,0 +1,6 @@
+INSERT INTO SchemaStatus (scriptName, schemaStatus) VALUES ('2024_11_26_SSX_processing_results_dataCollectionId_Mandatory.sql', 'ONGOING');
+
+ALTER TABLE SSXProcessingResult MODIFY COLUMN dataCollectionId int(11) unsigned NOT NULL;
+
+UPDATE SchemaStatus SET schemaStatus = 'DONE' WHERE scriptName = '2024_11_26_SSX_processing_results_dataCollectionId_Mandatory.sql';
+


### PR DESCRIPTION
- SSX processing result table updated to make dataCollectionId mandatory
- New permission created for the beamline service users to create/update SSX processing results and attachments